### PR TITLE
added es6-promise

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('sass:watch', function() {
 
 //################ TEST ####################
 
-gulp.task('connect', ['watch'], function() {
+gulp.task('connect', function() {
   connect.server({
     root: [__dirname],
     livereload: true

--- a/modules/chariot.js
+++ b/modules/chariot.js
@@ -42,8 +42,9 @@ class Chariot {
 
     let pushState = history.pushState;
     history.pushState = function(state) {
+      let res = pushState.apply(history, arguments);
       processGetParams();
-      return pushState.apply(history, arguments);
+      return res;
     };
 
     processGetParams();

--- a/modules/step.js
+++ b/modules/step.js
@@ -59,6 +59,7 @@ class Step {
     Promise.all(promises).then(() => {
       this.cloneElements(this.selectors);
       this.setupRepositionHandlers();
+      this.renderTooltip();
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "devDependencies": {
     "babel": "^5.6.14",
-    "babel-eslint": "^3.1.23",
     "babelify": "^6.1.2",
     "browserify": "^10.2.6",
     "chai": "^3.0.0",
@@ -20,7 +19,6 @@
     "mocha": "^2.2.5",
     "mocha-traceur": "^2.1.0",
     "phantomjs": "^1.9.17",
-    "semistandard": "^6.1.2",
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
- Added es6-promise module. A promise is made for each selector, and all promises must resolve before cloning is attempted.
- Watching resize event so that elements can be repositioned. Need to add listeners to individual selectors as well.
- disabled browserify's debug: true to allow normal debugging

/cc @rycfung @stephaniewei 
