### PR TITLE
getClonedElement no longer errors

### DIFF
--- a/modules/step.js
+++ b/modules/step.js
@@ -78,7 +78,7 @@ class Step {
 
   getClonedElement(selectorName) {
     let elementInfo = this._elementMap[selectorName];
-    if (!elementInfo) return null;
+    if (!elementInfo) return;
     return elementInfo.clone;
   }
 

--- a/test/libs/style_test.js
+++ b/test/libs/style_test.js
@@ -4,49 +4,42 @@ import chai from 'chai';
 import sinon from 'sinon';
 let expect = chai.expect;
 
-describe('Styles', () => {
-  context('caclulate left position', () => {
-    let tooltip = { outerWidth: () => {
-      return 20;
-    }
-  };
+describe('Styles', function() {
+  context('caclulate left position', function() {
+    let tooltip = { outerWidth: () => 20 };
     let anchor = {
-      offset: () => {
-        return { left: 100 }
-      },
-      outerWidth: () => {
-        return 200;
-      }
+      offset: () => ({ left: 100 }),
+      outerWidth: () => 200
     };
     let xOffset = 5, arrowOffset = 5;
 
-    describe("anchor to right", () => {
-      it("with offset", () => {
+    describe("anchor to right", function() {
+      it("with offset", function() {
         let offset = Style.calculateLeft(tooltip, anchor, xOffset, 'right', 0);
         expect(offset).to.be.equal(100 + 200 + xOffset);
       });
 
-      it("with offset and arrowOffset", () => {
+      it("with offset and arrowOffset", function() {
         let offset = Style.calculateLeft(tooltip, anchor, xOffset, 'right', arrowOffset);
         expect(offset).to.be.equal(100 + 200 + xOffset + arrowOffset);
       });
     });
 
-    describe("anchor to left", () => {
-      it("with offset", () => {
+    describe("anchor to left", function() {
+      it("with offset", function() {
         let offset = Style.calculateLeft(tooltip, anchor, xOffset, 'left', 0);
         expect(offset).to.be.equal(100 - 20 + xOffset);
       });
 
-      it("with offset and arrowOffset", () => {
+      it("with offset and arrowOffset", function() {
         let offset = Style.calculateLeft(
           tooltip, anchor, xOffset, 'left', arrowOffset);
         expect(offset).to.be.equal(100 - 20 + xOffset - arrowOffset);
       });
     });
 
-    describe("anchor to top/bottom", () => {
-      it("with offset", () => {
+    describe("anchor to top/bottom", function() {
+      it("with offset", function() {
         let topOffset = Style.calculateLeft(tooltip, anchor, xOffset, 'top', 0);
         let bottomOffset = Style.calculateLeft(
           tooltip, anchor, xOffset, 'bottom', 0);
@@ -55,7 +48,7 @@ describe('Styles', () => {
         expect(bottomOffset).to.be.equal(expected);
       });
 
-      it("with arrowOffset not factored in", () => {
+      it("with arrowOffset not factored in", function() {
         let topOffset = Style.calculateLeft(
           tooltip, anchor, xOffset, 'bottom', arrowOffset);
         let bottomOffset = Style.calculateLeft(
@@ -67,49 +60,42 @@ describe('Styles', () => {
     });
   });
 
-  context('calculate top position', () => {
-    let tooltip = { outerHeight: () => {
-      return 20;
-    }
-  };
+  context('calculate top position', function() {
+    let tooltip = { outerHeight: () => 20 };
     let anchor = {
-      offset: () => {
-        return { top: 100 }
-      },
-      outerHeight: () => {
-        return 200;
-      }
+      offset: () => ({ top: 100 }),
+      outerHeight: () => 200
     };
     let yOffset = 5, arrowOffset = 5;
 
-    describe("anchor to top", () => {
-      it("with offset", () => {
+    describe("anchor to top", function() {
+      it("with offset", function() {
         let offset = Style.calculateTop(tooltip, anchor, yOffset, 'bottom', 0);
         expect(offset).to.be.equal(100 + 200 + yOffset);
       });
 
-      it("with offset and arrowOffset", () => {
+      it("with offset and arrowOffset", function() {
         let offset = Style.calculateTop(
           tooltip, anchor, yOffset, 'bottom', arrowOffset);
         expect(offset).to.be.equal(100 + 200 + yOffset + arrowOffset);
       });
     });
 
-    describe("anchor to bottom", () => {
-      it("with offset", () => {
+    describe("anchor to bottom", function() {
+      it("with offset", function() {
         let offset = Style.calculateTop(tooltip, anchor, yOffset, 'top', 0);
         expect(offset).to.be.equal(100 - 20 + yOffset);
       });
 
-      it("with offset and arrowOffset", () => {
+      it("with offset and arrowOffset", function() {
         let offset = Style.calculateTop(
           tooltip, anchor, yOffset, 'top', arrowOffset);
         expect(offset).to.be.equal(100 - 20 + yOffset - arrowOffset);
       });
     });
 
-    describe("anchor to left/right", () => {
-      it("with offset", () => {
+    describe("anchor to left/right", function() {
+      it("with offset", function() {
         let topOffset = Style.calculateTop(tooltip, anchor, yOffset, 'left', 0);
         let bottomOffset = Style.calculateTop(
           tooltip, anchor, yOffset, 'right', 0);
@@ -118,7 +104,7 @@ describe('Styles', () => {
         expect(bottomOffset).to.be.equal(expected);
       });
 
-      it("with arrowOffset not factored in", () => {
+      it("with arrowOffset not factored in", function() {
         let topOffset = Style.calculateTop(
           tooltip, anchor, yOffset, 'left', arrowOffset);
         let bottomOffset = Style.calculateTop(

--- a/test/step_test.js
+++ b/test/step_test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 let expect = chai.expect;
 
 
-describe('Step', () => {
+describe('Step', function() {
   let stepConfiguration = {
     name: 'Internal or Public?',
     selectors: {
@@ -33,49 +33,49 @@ describe('Step', () => {
     }
   };
 
-  context('constructor', () => {
+  context('constructor', function() {
     let step = null,
       tutorial = null;
 
-    before(() => {
+    before(function() {
       tutorial = new Tutorial('test', { steps: [] });
       step = new Step(stepConfiguration, tutorial);
     });
 
-    it('reads selectors', () => {
+    it('reads selectors', function() {
       expect(step.selectors).to.equal(stepConfiguration.selectors);
     });
 
-    it('reads before and after', () => {
+    it('reads before and after', function() {
       expect(step.before).to.be.a('Function');
       expect(step.before()).to.equal(stepConfiguration.before());
       expect(step.after).to.be.a('Function');
       expect(step.after()).to.equal(stepConfiguration.after());
     });
 
-    it('reads tutorial', () => {
+    it('reads tutorial', function() {
       expect(step.tutorial).to.equal(tutorial);
     });
   });
 
-  context('getClonedElement', () => {
+  context('getClonedElement', function() {
     let step = null;
 
-    before(() => {
+    before(function() {
       step = new Step(stepConfiguration);
     });
 
-    it('returns null for invalid selectorName', () => {
+    it('returns null for invalid selectorName', function() {
       let result = step.getClonedElement('random');
-      expect(result).to.equal(null);
+      expect(result).to.equal(undefined);
     });
 
-    it('returns undefined for selectorName that has not been cloned', () => {
+    it('returns undefined for selectorName that has not been cloned', function() {
       let result = step.getClonedElement('assignee');
       expect(result).to.equal(undefined);
     });
 
-    it('returns clone for selectorName', () => {
+    it('returns clone for selectorName', function() {
       let selectorName = 'assignee';
       let clone = 'clone';
       step._elementMap[selectorName].clone = clone;
@@ -84,23 +84,23 @@ describe('Step', () => {
     });
   });
 
-  context('tearDown', () => {
+  context('tearDown', function() {
     let step = null,
       tutorial = null;
 
-    before(() => {
+    before(function() {
       tutorial = new Tutorial('test', { steps: [] });
       step = new Step(stepConfiguration, tutorial);
       sinon.stub(step.tooltip, ('tearDown'));
     });
 
-    it('clears cached styles', () => {
+    it('clears cached styles', function() {
       sinon.stub(Style, 'clearCachedStylesForElement');
       step.tearDown();
       expect(Style.clearCachedStylesForElement.calledTwice).to.be.true;
     });
 
-    it('removes all clone elements', () => {
+    it('removes all clone elements', function() {
       for (let selectorName in stepConfiguration.selectors) {
         let clone = { remove: () => {} };
         sinon.spy(clone, 'remove');
@@ -113,7 +113,7 @@ describe('Step', () => {
       }
     });
 
-    it('tears down tooltip', () => {
+    it('tears down tooltip', function() {
       expect(step.tooltip.tearDown.called).to.be.true;
     });
   });

--- a/test/tooltip_test.js
+++ b/test/tooltip_test.js
@@ -7,7 +7,7 @@ import $ from 'jquery';
 
 let expect = chai.expect;
 
-describe('Tooltip', () => {
+describe('Tooltip', function() {
   let configuration = {
       position: 'right', // 'top' | 'left' | 'bottom' | 'right'
       text: 'Some text',
@@ -19,18 +19,18 @@ describe('Tooltip', () => {
       iconUrl: '/assets/whatever',
       title: 'Title',
       cta: 'Next',
-      subtext: function() {return 'foobar';},
+      subtext: () => 'foobar',
       attr: {},
       arrowLength: 10
     },
     step = { selectors: {} },
     tutorial = new Object({
-      currentStep: function() { return 1; },
+      currentStep: () => 1,
       steps: [step]
     }),
     tooltip = null;
 
-  beforeEach(() => {
+  beforeEach(function() {
     tooltip = new Tooltip(configuration, step, tutorial);
   });
 
@@ -73,30 +73,32 @@ describe('Tooltip', () => {
     });
   });
 
-  context('render', () => {
-    it('sets css styles', () => {
+  context('render', function() {
+    it('sets css styles', function() {
       let css = sinon.stub().returns();
       let $markup = $('<div></div>');
-      sinon.stub(tooltip, '_createTooltipTemplate', () => { return $markup });
-      sinon.stub(tooltip, '_getAnchorElement', () => ({}));
-      sinon.stub(Style, "calculateTop", () => {return 0});
-      sinon.stub(Style, "calculateLeft", () => {return 0});
+      sinon.stub(tooltip, '_createTooltipTemplate').returns($markup);
+      sinon.stub(tooltip, '_getAnchorElement').returns({});
+      sinon.stub(Style, "calculateTop").returns(0);
+      sinon.stub(Style, "calculateLeft").returns(0);
 
       tooltip.render();
 
       expect($markup.css('position')).to.equal('absolute');
       expect($markup.css('top')).to.equal("0px");
       expect($markup.css('left')).to.equal("0px");
-      expect(parseInt($markup.css('z-index'))).to.equal(parseInt(tooltip.z_index));
+      expect(parseInt($markup.css('z-index'))).to.equal(
+        parseInt(tooltip.z_index));
     })
   });
 
-  context('tearDown', () => {
-    it('tearDown with null DOM element', () => {
+  context('tearDown', function() {
+    it('tearDown with null DOM element', function() {
       tooltip.$tooltip = null;
       expect(tooltip.tearDown.bind(tooltip)).not.to.throw(Error);
     });
-    it('tearDown removes element', () => {
+
+    it('tearDown removes element', function() {
       let $tooltip = { remove: () => ({}) }
       tooltip.$tooltip = $tooltip;
       sinon.spy($tooltip, 'remove');
@@ -108,22 +110,27 @@ describe('Tooltip', () => {
     });
   });
 
-  context('_createTooltipTemplate', () => {
+  context('_createTooltipTemplate', function() {
     let template = null;
-    beforeEach(() => {
+
+    beforeEach(function() {
       template = tooltip._createTooltipTemplate();
     });
 
-    it('uses elements from config to create markup', () => {
+    it('uses elements from config to create markup', function() {
       let templateHtml = template.html();
       expect(tooltip.cta).to.equal(configuration.cta);
       expect(tooltip.subtext).to.equal(configuration.subtext);
-      expect(template.attr('class').includes('step-1')).to.be.true;
       expect(templateHtml.includes(tooltip.title)).to.be.true;
       expect(templateHtml.includes(tooltip.text)).to.be.true;
       expect(templateHtml.includes(tooltip.cta)).to.be.true;
       expect(templateHtml.includes(tooltip.iconUrl)).to.be.true;
       expect(templateHtml.includes(tooltip.subtext())).to.be.true;
+    });
+
+    it('includes step number in CSS class and data attribute', function() {
+      expect(template.attr('class').includes('chariot-step')).to.be.true;
+      expect(template.attr('data-step-order').includes(1)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
getClonedElement was previously throwing errors for invalid selectorName

/cc @zendesk/zobu
