### PR TITLE
replaced ES6 Map with dictionary

### DIFF
--- a/modules/step.js
+++ b/modules/step.js
@@ -21,7 +21,7 @@ class Step {
     this.after = config.after;
     this._resizeTimeout = null;
 
-    this._elementMap = new Map();
+    this._elementMap = {};
     for (let selectorName in this.selectors) {
       this._elementMap[selectorName] = {};
     }


### PR DESCRIPTION
IE9 was complaining about Map being undefined.  This PR replaces ES6 Map with a dictionary.

### Risks
- Low.  Map functionally is a superset of a plain old dictionary, so nothing else needs to be updated.  Just have to confirm IE works.
