### PR TITLE
Remove jquery as dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script type="text/javascript" src="./node_modules/jquery/dist/jquery.js"></script>
 <script type="text/javascript" src="./dist/javascripts/chariot.js"></script>
 <link rel="stylesheet" type="text/css" href="./dist/stylesheets/chariot.css">
 

--- a/modules/config.example.js
+++ b/modules/config.example.js
@@ -54,6 +54,7 @@
 
 /**
  * Callback called once after step is rendered.
+ * Specifically, this is called immediately after the tooltip is rendered.
  * @callback Step-afterCallback
  */
 

--- a/modules/libs/style.js
+++ b/modules/libs/style.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 const CHARIOT_COMPUTED_STYLE_CLASS_PREFIX = 'chariot_computed_styles';
 
 class Style {

--- a/modules/overlay.js
+++ b/modules/overlay.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import { OVERLAY_Z_INDEX, CLONE_Z_INDEX } from './constants';
 
 class Overlay {

--- a/modules/step.js
+++ b/modules/step.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import debounce from 'lodash.debounce';
 import Tooltip from './tooltip';
 import { CLONE_Z_INDEX } from './constants';

--- a/modules/tooltip.js
+++ b/modules/tooltip.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import { TOOLTIP_Z_INDEX } from './constants';
 import Style from './libs/style';
 

--- a/modules/tutorial.js
+++ b/modules/tutorial.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import Step from './step';
 import Overlay from './overlay';
 let Promise = require('es6-promise').Promise;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-util": "^3.0.6",
     "jscs": "^2.0.0",
     "jsdoc": "^3.3.2",
+    "jquery": "^2.1.4",
     "mocha": "^2.2.5",
     "npm-shrinkwrap": "^5.4.0",
     "phantomjs": "^1.9.17",
@@ -42,7 +43,6 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "jquery": "^2.1.4",
     "lodash.debounce": "^3.1.1",
     "query-parse": "^0.1.1"
   },

--- a/test/step_test.js
+++ b/test/step_test.js
@@ -3,7 +3,6 @@ require('./test_helper');
 import Step from '../modules/step';
 import Tutorial from '../modules/tutorial';
 import Style from '../modules/libs/style';
-import $ from 'jquery';
 import chai from 'chai';
 import sinon from 'sinon';
 let expect = chai.expect;

--- a/test/tooltip_test.js
+++ b/test/tooltip_test.js
@@ -3,7 +3,6 @@ import Tooltip from '../modules/tooltip';
 import chai from 'chai';
 import sinon from 'sinon';
 import Style from '../modules/libs/style';
-import $ from 'jquery';
 
 let expect = chai.expect;
 

--- a/testem.yml
+++ b/testem.yml
@@ -1,6 +1,7 @@
 {
   "framework": "mocha",
   "src_files": [
+    "node_modules/jquery/dist/jquery.js",
     "dist/test/test.js",
   ],
   "launch_in_ci": [


### PR DESCRIPTION
jquery is no longer a hard dependency, and now a devDependency.
Removed all import statements.

### Risks
- Low.  Ensure chariot still works w/o jquery dependency, which should happen as long as the project implementing Chariot pulls in jquery.
