### PR TITLE
Extend the Chariot.startTutorial API

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,7 +104,6 @@ gulp.task("compile-test", function() {
 
 gulp.task('js-doc', shell.task([
   './node_modules/.bin/jsdoc modules/* --destination docs/'
-//  './node_modules/.bin/jsdoc modules/config.example.js --destination docs/'
 ]));
 
 gulp.task('style', function () {
@@ -165,6 +164,7 @@ gulp.task('git-tag', function(cb){
 gulp.task('build-release',function(cb){
   return runSequence(
     'style-fix',
+    'js-doc',
     ['clean'],
     ['js-minify', 'css-minify'],
     'prepend-version',

--- a/index.html
+++ b/index.html
@@ -38,18 +38,12 @@
     background: pink;
   }
 </style>
-<script>
-
-function click() {
-	history.pushState({}, "page 2", "index.html?tutorial=ticketing");
-}
-
-</script>
 
 </head>
 
 <body>
-<a href='javascript:click()'>Add history</a>
+  <div><a href="#" class="add-history-link">1. Add history</a></div>
+  <div><a href="#" class="start-tutorial-link">2. Start tutorial without URL change</a></div>
 <div class='outer'>
   <div class="inner top-left"><button>Top Left</button></div>
   <div class="inner top-right"><button>Top Right</button></div>
@@ -58,7 +52,7 @@ function click() {
 
 <script>
 
-new Chariot({
+var chariot = new Chariot({
   ticketing: {
     steps: [
       // Step #1 illustrates the basic content of a tooltip
@@ -141,11 +135,24 @@ new Chariot({
       */
     ],
     // shouldOverlay: false,
-    complete: function(){
-
+    onComplete: function() {
+      console.log('onComplete called from configuration');
     },
     compatibilityMode: true
   }
+});
+
+
+$(function() {
+  $('.add-history-link').click(function() {
+    history.pushState({}, "page 2", "index.html?tutorial=ticketing");
+  });
+
+  $('.start-tutorial-link').click(function() {
+    chariot.startTutorial('ticketing', function() {
+      console.log('onComplete called from argument to Chariot.startTutorial()');
+    });
+  });
 });
 </script>
 </body>

--- a/modules/chariot.js
+++ b/modules/chariot.js
@@ -18,12 +18,22 @@ class Chariot {
     this.currentTutorial = null;
   }
 
-  startTutorial(name) {
+  /**
+   * @param {string} name - Name of the tutorial to start
+   * @param {function} [onComplete] - Callback that is called
+   * once the tutorial has gone through all steps.
+   * Note: Overrides TutorialConfiguration.onComplete
+   */
+  startTutorial(name, onComplete) {
     if (this.currentTutorial) {
       return;
     }
     this.currentTutorial = this.tutorials[name];
     this.currentTutorial.start();
+    if (onComplete) {
+      debugger;
+      this.currentTutorial.onComplete = onComplete;
+    }
   }
 
   endTutorial() {

--- a/modules/config.example.js
+++ b/modules/config.example.js
@@ -8,7 +8,7 @@
  */
 
 /** The tutorial configuration is where the steps of a tutorial are specified,
- * and also allows customization of the overlay style. A complete callback is
+ * and also allows customization of the overlay style. A onComplete callback is
  * available for end of tutorial cleanup.
  *
  * @typedef TutorialConfiguration
@@ -16,7 +16,7 @@
  * overlay that normally appears over the page and behind the tooltips.
  * @property {string} [overlayColor='rgba(255,255,255,0.7)'] - Overlay CSS color
  * @property {StepConfiguration[]} steps - An array of step configurations (see below).
- * @property {Tutorial-completeCallback} [complete] - Callback that is called
+ * @property {Tutorial-onCompleteCallback} [onComplete] - Callback that is called
  * once the tutorial has gone through all steps.
  * @property {boolean} [compatibilityMode=false] - Setting to true will use an
  *  implementation that does not rely on cloning highlighted elements.
@@ -28,7 +28,7 @@
 
 /**
  * Callback is called after the tutorial has finished all steps.
- * @callback Tutorial-completeCallback
+ * @callback Tutorial-onCompleteCallback
  */
 
 /** The step configuration is where you specify which elements of the page will
@@ -150,7 +150,7 @@ var OnboardingConfig = {
         }
       }
     ],
-    complete: () => {
+    onComplete: () => {
     },
     shouldOverlay: true,
     compatibilityMode: true

--- a/modules/tutorial.js
+++ b/modules/tutorial.js
@@ -10,7 +10,7 @@ class Tutorial {
       return;
     }
 
-    this.complete = typeof config.complete === 'function' ? config.complete : ()=> {};
+    this.onComplete = typeof config.onComplete === 'function' ? config.onComplete : ()=> {};
     this.compatibilityMode = config.compatibilityMode || false;
 
     this.steps = [];
@@ -69,17 +69,17 @@ class Tutorial {
 
   toString() {
     return `[Tutorial - compatibilityMode: {this.compatibilityMode}, ` +
-      `complete: {this.complete}, steps: ${this.steps}, overlay: ` +
+      `onComplete: {this.onComplete}, steps: ${this.steps}, overlay: ` +
       `${this.overlay}]`;
   }
 
   //// PRIVATE
 
   _end() {
-    // Note: Order matters. complete callback should be called after UI is torn down
+    // Note: Order matters. onComplete callback should be called after UI is torn down
     this.tearDown();
     this.chariot.endTutorial();
-    this.complete();
+    this.onComplete();
   }
 }
 


### PR DESCRIPTION
- Added an onComplete argument to `Chariot.startTutorial()` that overrides the `TutorialConfiguration.onComplete` parameter.
- Edited release task to also call js-doc.

@rycfung 
cc @zendesk/zobu 
