### PR TITLE
Temporary background overlay to appears before waiting for elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ To run a simple server:
 	gulp connect
 
 This will start a simple server that serves `index.html` at
-http://localhost:8080/example/index.html, and loads `chariot.js` onto the page.
+[http://localhost:8080/example/index.html](http://localhost:8080/example/index.html),
+ and loads `chariot.js` onto the page.
 The task will also watch your changes and reloads the page as the files are updated.
 
 Run the following style-checker before pushing your branch.

--- a/example/index.html
+++ b/example/index.html
@@ -148,66 +148,44 @@ var chariot = new Chariot({
   }
 }, delegate);
 
-function sleepFor(sleepDuration){
-  var now = new Date().getTime();
-  while(new Date().getTime() < now + sleepDuration){ /* do nothing */ }
+function sleepFor(sleepDuration, message) {
+  return new Promise(resolve => {
+    setTimeout(resolve, sleepDuration);
+    console.log(message);
+  });
 }
 
 function willBeginTutorial(tutorial) {
   console.log("delegate - willBeginTutorial\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("willBeginTutorial promise resolved");
-  });
+  return sleepFor(1000, "willBeginTutorial promise resolved");
 }
 function willBeginStep(step, stepIndex, tutorial) {
   console.log("delegate - willBeginStep\n  step:" + step + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("willBeginStep promise resolved");
-  });
+  return sleepFor(1000, "willBeginStep promise resolved");
 }
 function willShowOverlay(overlay, stepIndex, tutorial) {
   console.log("delegate - willShowOverlay\n  overlay:" + overlay + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("willShowOverlay promise resolved");
-  });
+  return sleepFor(1000, "willShowOverlay promise resolved");
 }
 function didShowOverlay(overlay, stepIndex, tutorial) {
   console.log("delegate - didShowOverlay\n  overlay:" + overlay + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("didShowOverlay promise resolved");
-  });
+  return sleepFor(1000, "didShowOverlay promise resolved");
 }
 function willRenderTooltip(tooltip, stepIndex, tutorial) {
   console.log("delegate - willRenderTooltip\n  tooltip:" + tooltip + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("willRenderTooltip promise resolved");
-  });
+  return sleepFor(1000, "willRenderTooltip promise resolved");
 }
 function didRenderTooltip(tooltip, stepIndex, tutorial) {
   console.log("delegate - didRenderTooltip\n  tooltip:" + tooltip + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("didRenderTooltip promise resolved");
-  });
+  return sleepFor(1000, "didRenderTooltip promise resolved");
 }
 function didFinishStep(step, stepIndex, tutorial) {
   console.log("delegate - didFinishStep\n  step:" + step + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("didFinishStep promise resolved");
-  });
+  return sleepFor(1000, "didFinishStep promise resolved");
 }
 function didFinishTutorial(tutorial, forced) {
   console.log("delegate - didFinishTutorial\n  tutorial:" + tutorial + " forced:" + forced);
-  return Promise.resolve().then(() => {
-    sleepFor(1000);
-    console.log("didFinishTutorial promise resolved");
-  });
+  return sleepFor(1000, "didFinishTutorial promise resolved");
 }
 
 $(function() {

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -37,8 +37,13 @@ class Overlay {
     return this.useTransparentOverlayStrategy;
   }
 
-  // Following 2 methods are part of clone element strategy
+  // The following 2 methods are part of the "clone element" strategy
 
+  /**
+   * Shows a background overlay to obscure the main interface, and acts as the
+   * background for the cloned elements involved in the tutorial.
+   * This method is involved in the "clone element" strategy.
+   */
   showBackgroundOverlay() {
     // Remove the resize handler that might exist from focusOnElement
     // (Note: take care to not call this after cloning elements, because they
@@ -54,11 +59,19 @@ class Overlay {
     this._resizeHandler = this._resizeOverlayToFullScreen.bind(this);
   }
 
+  /**
+   * Shows a transparent overlay to prevent user from interacting with cloned
+   * elements.
+   */
   showTransparentOverlay() {
     this.$transparentOverlay.show();
   }
 
-  // One transparent overlay strategy
+  /**
+   * Focuses on an element by resizing a transparent overlay to match its
+   * dimensions and changes the borders to be colored to obscure the main UI.
+   * This method is involved in the "transparent overlay" strategy.
+   */
   focusOnElement($element) {
     // Hide overlay from showTransparentOverlay
     this.$transparentOverlay.hide();

--- a/lib/step.js
+++ b/lib/step.js
@@ -59,20 +59,23 @@ class Step {
           this, this.index, this.tutorial);
       }
     }).then(() => {
-      return this._waitForElements();
-    }).then(() => {
       if (this.delegate.willShowOverlay) {
         return this.delegate.willShowOverlay(
           this.overlay, this.index, this.tutorial);
       }
     }).then(() => {
+      // Show a temporary background overlay while we wait for elements
+      this.overlay.showBackgroundOverlay();
+      return this._waitForElements();
+    }).then(() => {
       // Render the overlay
       if (this.overlay.isTransparentOverlayStrategy() &&
           Object.keys(this.selectors).length === 1) {
-        this._transparentOverlayStrategy();
+        this._singleTransparentOverlayStrategy();
       } else {
         this._clonedElementStrategy();
       }
+    }).then(() => {
       if (this.delegate.didShowOverlay) {
         return this.delegate.didShowOverlay(
           this.overlay, this.index, this.tutorial);
@@ -169,7 +172,7 @@ class Step {
 
   //// PRIVATE
 
-  _transparentOverlayStrategy() {
+  _singleTransparentOverlayStrategy() {
     // Only use an overlay
     let selectorName = Object.keys(this.selectors)[0];
     let $element =  this._elementMap[selectorName].element;
@@ -178,7 +181,6 @@ class Step {
 
   _clonedElementStrategy() {
     // Clone elements if multiple selectors
-    this.overlay.showBackgroundOverlay();
     this._cloneElements(this.selectors);
     this.overlay.showTransparentOverlay();
   }


### PR DESCRIPTION
- A temporary background overlay is now rendered before waiting for elements to appear on screen.
- Updated example to actually sleep for duration without blocking main thread.

@rycfung 
/cc @zendesk/zobu
