### PR TITLE
Added a Chariot.startTutorial method 

### DIFF
--- a/lib/chariot.js
+++ b/lib/chariot.js
@@ -171,6 +171,19 @@ class Chariot {
     return new Tutorial(config, '', delegate);
   }
 
+  /**
+   * Static method for creating and starting a Tutorial object without needing
+   * to instantiate chariot with a large configuration and named tutorials.
+   * @param {TutorialConfiguration} config - The tutorial configuration
+   * @param {ChariotDelegate} [delegate] - An optional delegate that responds to
+   *  lifecycle callbacks
+   */
+  static startTutorial(config, delegate) {
+    const tutorial = this.createTutorial(config, delegate);
+    tutorial.start();
+    return tutorial;
+  }
+
   toString() {
     return `[Chariot - config: ${this.config}, tutorials: {this.tutorials}]`;
   }

--- a/test/chariot_test.js
+++ b/test/chariot_test.js
@@ -48,10 +48,21 @@ describe('Chariot', function() {
     });
   });
 
-  describe('#createTutorial', function() {
+  describe('#Chariot.createTutorial', function() {
     it('returns a tutorial with a valid config', function() {
       let tutorial = Chariot.createTutorial(config[tutorialName], delegate);
       expect(tutorial).to.not.equal(null);
+    });
+  });
+
+  describe('#Chariot.startTutorial', function() {
+    it('returns and starts a tutorial with a valid config', function() {
+      let stub = { start: () => '' };
+      sinon.stub(Chariot, 'createTutorial').returns(stub);
+      sinon.stub(stub, 'start');
+      let tutorial = Chariot.startTutorial(config[tutorialName], delegate);
+      expect(tutorial).to.equal(stub);
+      expect(stub.start.called).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Added a `Chariot.startTutorial` class method to make starting a tutorial a one liner.

@rycfung @danielstjules 