### PR TITLE
Step configuration's 'selectors' parameter can be multiple types

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -10,16 +10,21 @@ let Promise = require('es6-promise').Promise;
 
 class Step {
 
-  /** The step configuration is where you specify which elements of the page will
-   * be cloned and placed over the overlay.
+  /** The step configuration is where you specify which elements of the page
+   * will be cloned and placed over the overlay. These elements are the
+   * what appear as highlighted to the user.
    *
    * @typedef StepConfiguration
    * @property {TooltipConfiguration} tooltip - Tooltip configuration.
-   * @property {Object.<string, string>} [selectors] - Contains arbitrarily-named
-   *  keys with CSS selector values. These keys can be referenced from
-   *  TooltipConfiguration.anchorElement.
-   *  Note: Specifying a selector that lives within another specified selector will
-   *  result in unpredictable behavior.
+   * @property {Object.<string, string>|string[]|string} [selectors] -
+   *  Object with arbitrarily-named keys and CSS selector values.
+   *  These keys can then be referenced from TooltipConfiguration.anchorElement.
+   *  Or, an array of selector strings if named keys are not required.
+   *  Or, a string if only one selector is required.
+   *  Notes: Specifying a selector that targets another specified selector
+   *  will result in unpredictable behavior.
+   *  Specifying multiple selectors will effectively cause
+   *  Tutorial.useTransparentOverlayStrategy == false.
    */
 
   /**
@@ -40,8 +45,20 @@ class Step {
     if (!config.selectors || !Object.keys(config.selectors).length) {
       throw new Error('selectors must be present in Step configuration\n' +
         this);
+    } else if (Object.prototype.toString.call(config.selectors) === '[object Object]') {
+      this.selectors = config.selectors;
+    } else if (Object.prototype.toString.call(config.selectors) === '[object Array]') {
+      const selectorsMap = {};
+      config.selectors.forEach((val, idx) => {
+        selectorsMap[idx] = val;
+      });
+      this.selectors = selectorsMap;
+    } else if (typeof config.selectors === 'string') {
+      this.selectors = { 0: config.selectors };
+    } else {
+      throw new Error('selectors must be an object, array, or string');
     }
-    this.selectors = config.selectors;
+
     this._resizeTimeout = null;
 
     this._elementMap = {};


### PR DESCRIPTION
`Step` configuration's `selectors` parameter can be multiple types: object, array, or string.

This will make the configuration of chariot less verbose for users who don't need named selectors.

@zenrfung 