### PR TITLE
Simplified TutorialConfiguration 

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -170,22 +170,16 @@ $(function() {
   });
 
   $('.create-tutorial-link').click(function() {
-    var tutorial = Chariot.createTutorial({
-      steps: [
-        {
-          selectors: {
-            link: ".create-tutorial-link"
-          },
-          tooltip: {
-            position: 'right',
-            title: 'Launch tutorials ad-hoc without a massive up-front configuration',
-            text: 'Dynamically create tutorials and launch them without needing to instantiate chariot first.'
-          }
+    Chariot.startTutorial([
+      {
+        selectors: ".create-tutorial-link",
+        tooltip: {
+          position: 'right',
+          title: 'Launch tutorials ad-hoc without a massive up-front configuration',
+          text: 'Dynamically create tutorials and launch them without needing to instantiate chariot first.'
         }
-      ],
-      useTransparentOverlayStrategy: true
-    }, delegate);
-    tutorial.start();
+      }
+    ], delegate);
   });
 });
 </script>

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -11,7 +11,7 @@ class Overlay {
   constructor(config) {
     this.shouldOverlay = config.shouldOverlay === undefined ? true : config.shouldOverlay;
     this.overlayColor = config.overlayColor || 'rgba(255,255,255,0.8)';
-    this.useTransparentOverlayStrategy = config.useTransparentOverlayStrategy;
+    this.useTransparentOverlayStrategy = !!config.useTransparentOverlayStrategy;
     this._resizeHandler = null;
   }
 

--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -8,6 +8,9 @@ class Tutorial {
   /**
    * The tutorial configuration is where the steps of a tutorial are specified,
    * and also allows customization of the overlay style.
+   * If optional configuration parameters are not required, the steps property
+   * array can be passed in directly as the configuration.
+   *
    * Notes on implementation:
    * The elements defined in each step of a tutorial via
    * StepConfiguration.selectors are highlighted using transparent overlays.
@@ -29,11 +32,13 @@ class Tutorial {
    * StepConfiguration.selectors.
    *
    * @typedef TutorialConfiguration
+   * @property {StepConfiguration[]} steps - An array of step configurations (see below).
+   *  Note that this property can be passed as the configuration if the
+   *  optional params below are not used.
    * @property {integer} [zIndex=20] - Sets the base z-index value used by this tutorial
    * @property {boolean} [shouldOverlay=true] - Setting to false will disable the
    * overlay that normally appears over the page and behind the tooltips.
    * @property {string} [overlayColor='rgba(255,255,255,0.7)'] - Overlay CSS color
-   * @property {StepConfiguration[]} steps - An array of step configurations (see below).
    * @property {Tutorial-onCompleteCallback} [onComplete] - Callback that is called
    * once the tutorial has gone through all steps.
    * @property {boolean} [useTransparentOverlayStrategy=false] - Setting to true will use an
@@ -52,17 +57,29 @@ class Tutorial {
    *  lifecycle callbacks
    */
   constructor(config, name, delegate) {
-    if (typeof config.steps !== 'object') {
-      throw new Error(`steps must be an array.\n${this}`);
-      return;
-    }
     this.name = name;
-    this.zIndex = config.zIndex;
     this.delegate = delegate || {};
-    this.useTransparentOverlayStrategy = config.useTransparentOverlayStrategy || false;
     this.steps = [];
-    this.overlay = new Overlay(config);
-    config.steps.forEach((step, index) => {
+
+    const configType = Object.prototype.toString.call(config);
+    let steps, overlayConfig;
+    if (configType === '[object Array]') {
+      steps = config;
+      overlayConfig = {};
+    } else if (configType === '[object Object]') {
+      if (!Array.isArray(config.steps)) {
+        throw new Error(`steps must be an array.\n${this}`);
+      }
+      this.zIndex = config.zIndex;
+      this.useTransparentOverlayStrategy = config.useTransparentOverlayStrategy;
+      steps = config.steps;
+      overlayConfig = config;
+    } else {
+      throw new Error('config must be an object or array');
+    }
+
+    this.overlay = new Overlay(overlayConfig);
+    steps.forEach((step, index) => {
       this.steps.push(new Step(step, index, this, this.overlay, this.delegate));
     });
     this._prepared = false;


### PR DESCRIPTION
Simplified `TutorialConfiguration` by allowing the steps parameter to completely replace the configuration object if the other optional parameters in the `TutotrialConfiguration` are unused.

Before:
```
Chariot.startTutorial({
  steps: [
    {
      selectors: 'header',
      tooltip: {
        position: 'bottom',
        title: 'Chariot in action',
        text: 'This is an example Chariot tooltip.'
      }
    }
  ]
});
```

After:
```
Chariot.startTutorial([
  {
    selectors: 'header',
    tooltip: {
      position: 'bottom',
      title: 'Chariot in action',
      text: 'This is an example Chariot tooltip.'
    }
  }
]);
```
@zenrfung @danielstjules 