### PR TITLE
Fixed overlay dimensions and selector key collisions

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -40,6 +40,10 @@
   a {
     color: white;
   }
+  .far-below {
+    margin-top: 1000px;
+    background: green;
+  }
 </style>
 
 </head>
@@ -48,12 +52,14 @@
   <div><a href="#" class="add-history-link">1. Add history</a></div>
   <div><a href="#" class="start-tutorial-link">2. Start tutorial without URL change</a></div>
   <div><a href="#" class="create-tutorial-link">3. Create tutorial without chariot instance</a></div>
-<div class='outer'>
-  <div class="inner top-left"><button>Top Left</button></div>
-  <div class="inner top-right"><button>Top Right</button></div>
-  <div class="inner bottom-left"><button>Bottom Left</button></div>
-</div>
 
+  <div class='outer'>
+    <div class="inner top-left"><button>Top Left</button></div>
+    <div class="inner top-right"><button>Top Right</button></div>
+    <div class="inner bottom-left"><button>Bottom Left</button></div>
+  </div>
+
+  <div class="inner far-below"><button>Far Below</button></div>
 <script>
 
 var delegate = this;
@@ -162,35 +168,35 @@ function sleepFor(sleepDuration, message) {
 
 function willBeginTutorial(tutorial) {
   console.log("delegate - willBeginTutorial\n  tutorial:" + tutorial);
-  return sleepFor(1000, "willBeginTutorial promise resolved");
+  return sleepFor(0, "willBeginTutorial promise resolved");
 }
 function willBeginStep(step, stepIndex, tutorial) {
   console.log("delegate - willBeginStep\n  step:" + step + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "willBeginStep promise resolved");
+  return sleepFor(0, "willBeginStep promise resolved");
 }
 function willShowOverlay(overlay, stepIndex, tutorial) {
   console.log("delegate - willShowOverlay\n  overlay:" + overlay + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "willShowOverlay promise resolved");
+  return sleepFor(0, "willShowOverlay promise resolved");
 }
 function didShowOverlay(overlay, stepIndex, tutorial) {
   console.log("delegate - didShowOverlay\n  overlay:" + overlay + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "didShowOverlay promise resolved");
+  return sleepFor(0, "didShowOverlay promise resolved");
 }
 function willRenderTooltip(tooltip, stepIndex, tutorial) {
   console.log("delegate - willRenderTooltip\n  tooltip:" + tooltip + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "willRenderTooltip promise resolved");
+  return sleepFor(0, "willRenderTooltip promise resolved");
 }
 function didRenderTooltip(tooltip, stepIndex, tutorial) {
   console.log("delegate - didRenderTooltip\n  tooltip:" + tooltip + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "didRenderTooltip promise resolved");
+  return sleepFor(0, "didRenderTooltip promise resolved");
 }
 function didFinishStep(step, stepIndex, tutorial) {
   console.log("delegate - didFinishStep\n  step:" + step + "\n  stepIndex:" + stepIndex + "\n  tutorial:" + tutorial);
-  return sleepFor(1000, "didFinishStep promise resolved");
+  return sleepFor(0, "didFinishStep promise resolved");
 }
 function didFinishTutorial(tutorial, forced) {
   console.log("delegate - didFinishTutorial\n  tutorial:" + tutorial + " forced:" + forced);
-  return sleepFor(1000, "didFinishTutorial promise resolved");
+  return sleepFor(0, "didFinishTutorial promise resolved");
 }
 
 $(function() {
@@ -215,7 +221,8 @@ $(function() {
             text: 'Dynamically create tutorials and launch them without needing to instantiate chariot first.'
           },
         }
-      ]
+      ],
+      useTransparentOverlayStrategy: true
     }, delegate);
     tutorial.start();
   });

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -107,7 +107,9 @@ class Overlay {
   _createTransparentOverlay() {
     let $transparentOverlay = $("<div class='chariot-transparent-overlay'></div>");
     $transparentOverlay.css({
-      'z-index': Constants.CLONE_Z_INDEX + 1
+      'z-index': Constants.CLONE_Z_INDEX + 1,
+      width: document.body.scrollWidth,
+      height: document.body.scrollHeight
     });
     return $transparentOverlay;
   }
@@ -115,8 +117,8 @@ class Overlay {
   // Used for clone element strategy
   _resizeOverlayToFullScreen() {
     this.$overlay.css({
-      width: '100%',
-      height: '100%'
+      width: document.body.scrollWidth,
+      height: document.body.scrollHeight
     });
   }
 

--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -284,11 +284,12 @@ class Tooltip {
     // Look for already cloned elements first
     let clonedSelectedElement = this.step.getClonedElement(this.anchorElement);
     if (clonedSelectedElement) return clonedSelectedElement;
+    const anchorElement = this.step.selectors[this.anchorElement];
+    // Try fetching from selectors
+    let $element = $(anchorElement);
     // Try fetching from DOM
-    let $element = $(this.anchorElement);
     if ($element.length === 0) {
-      // Try fetching from selectors
-      $element = $(this.step.selectors[this.anchorElement]);
+      $element = $(this.anchorElement);
     }
     if ($element.length === 0) {
       console.log("Anchor element not found: " + this.anchorElement);


### PR DESCRIPTION
Fixed two bugs:

1. Overlay did not cover the whole screen when document scroll width/height exceeds viewport width/height

Before:
![screen shot 2016-11-08 at 4 41 56 pm](https://cloud.githubusercontent.com/assets/61457/20123675/ad2e4828-a5d5-11e6-9a90-75ba4d783855.png)


After:
![screen shot 2016-11-08 at 4 30 08 pm](https://cloud.githubusercontent.com/assets/61457/20123676/b03b179e-a5d5-11e6-856f-6e9b7a7a086a.png)


2. Selector name collisions with HTML tag names.
Given the following configuration and html:
```js
#TooltipConfiguration
{ 
  selectors: { link: '<button>' }
  ...
}
```
```html
<link rel="stylesheet" type="text/css" />

<button />
```
Having the key `link` in the selectors object would cause the tooltip's `anchorElement` to incorrectly bind to the `<link>` tag rather than the element specified in the selectors value (`<button>`) .

@zenrfung 