### PR TITLE
Add CSS animations to tooltips

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -121,7 +121,7 @@ var chariot = new Chariot({
 }, delegate);
 
 function sleepFor(sleepDuration, message) {
-  return new Promise(resolve => {
+  return new Promise(function(resolve) {
     setTimeout(resolve, sleepDuration);
     console.log(message);
   });

--- a/lib/step.js
+++ b/lib/step.js
@@ -42,10 +42,17 @@ class Step {
     this.index = index;
     this.overlay = overlay;
     this.delegate = delegate || {};
-    if (!config.selectors || !Object.keys(config.selectors).length) {
+
+    if (!config.selectors) {
       throw new Error('selectors must be present in Step configuration\n' +
         this);
+    } else if (typeof config.selectors === 'string') {
+      this.selectors = { 0: config.selectors };
     } else if (Object.prototype.toString.call(config.selectors) === '[object Object]') {
+      if (!Object.keys(config.selectors).length) {
+        throw new Error('selectors must be present in Step configuration\n' +
+          this);
+      }
       this.selectors = config.selectors;
     } else if (Array.isArray(config.selectors)) {
       const selectorsMap = {};
@@ -53,8 +60,6 @@ class Step {
         selectorsMap[idx] = val;
       });
       this.selectors = selectorsMap;
-    } else if (typeof config.selectors === 'string') {
-      this.selectors = { 0: config.selectors };
     } else {
       throw new Error('selectors must be an object, array, or string');
     }

--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -56,7 +56,6 @@ const DEFAULT_ARROW_LENGTH = 11;
  */
 
 class Tooltip {
-
   /**
    * @constructor
    * @param {TooltipConfiguration} config - The configuration for this tooltip
@@ -93,10 +92,11 @@ class Tooltip {
     this.offsetArrow = config.offsetArrow ? parseInt(config.offsetArrow) : 0;
 
     this.arrowClass = arrowClass;
+    this.appearAnimationClass = 'animate-appear-' + this.position;
 
     this.width = parseInt(config.width);
     this.height = parseInt(config.height);
-    let selectorKeys = Object.keys(this.step.selectors);
+    const selectorKeys = Object.keys(this.step.selectors);
     if (selectorKeys.length > 1 && !config.anchorElement) {
       throw new Error('anchorElement is not optional when more than one ' +
         'selector exists:\n' + this);
@@ -115,15 +115,17 @@ class Tooltip {
 
   render() {
     const $tooltip = this.$tooltip = this._createTooltipTemplate();
+
+    // Hide the tooltip first, in case we need to scroll into view first
+    $tooltip.css({ opacity: 0 });
     $('body').append($tooltip);
 
     const $tooltipArrow = this.$tooltipArrow = $('.chariot-tooltip-arrow');
-
     this._position($tooltip, $tooltipArrow);
 
-    // Add event handlers
+    // Add button event handler
     $('.chariot-btn-row button').click(() => {
-      this.next();
+      this._animateTooltipDisappear($tooltip);
     });
   }
 
@@ -202,6 +204,18 @@ class Tooltip {
   _position($tooltip, $tooltipArrow) {
     this._positionTooltip($tooltip);
     this._positionArrow($tooltip, $tooltipArrow);
+
+    // Animate scrolling to the tooltip if it's not completely visible
+    if (this.tutorial.animateScrolling && !this._isElementInViewport($tooltip)) {
+      $("html, body").animate({
+        scrollTop: $tooltip.offset().top + $tooltip.height() / 2 - document.body.clientHeight / 2,
+        scrollLeft: $tooltip.offset().left + $tooltip.width() / 2 - document.body.clientWidth / 2
+      }, this.tutorial.scrollAnimationDuration, () => {
+        this._animateTooltipAppear($tooltip);
+      });
+    } else {
+      this._animateTooltipAppear($tooltip);
+    }
   }
 
   _positionTooltip($tooltip) {
@@ -288,6 +302,43 @@ class Tooltip {
     }
 
     $tooltipArrow.css(arrowStyles);
+  }
+
+  _isElementInViewport($el) {
+    const rect = $el[0].getBoundingClientRect();
+
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
+    );
+  }
+
+  _animateTooltipAppear($tooltip) {
+    // Reveal the tooltip again
+    $tooltip.css({ opacity: 1 });
+    if (!this.tutorial.animateTooltips) {
+      return;
+    }
+    $tooltip.addClass(this.appearAnimationClass)
+      .one('animationend', (e) => {
+        $(e.currentTarget).removeClass(this.appearAnimationClass);
+      });
+  }
+
+  _animateTooltipDisappear($tooltip) {
+    if (!this.tutorial.animateTooltips) {
+      this.next();
+      return;
+    }
+
+    $tooltip
+      .addClass(this.appearAnimationClass)
+      .css({ 'animation-direction': 'reverse' })
+      .on('animationend', () => {
+        this.next();
+      });
   }
 
   _getAnchorElement() {

--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -1,7 +1,9 @@
 import Step from './step';
 import Overlay from './overlay';
-let Promise = require('es6-promise').Promise;
+const Promise = require('es6-promise').Promise;
 import Constant from './constants';
+
+const DEFAULT_SCROLL_ANIMATION_DURATION = 500;
 
 class Tutorial {
   /**
@@ -44,8 +46,16 @@ class Tutorial {
    *  implementation that does not rely on cloning highlighted elements.
    *  Note: This value is ignored if a step contains multiple selectors.
    *  useTransparentOverlayStrategy is named as such because
-   * @property {boolean} [animated=false] - (TODO) Enables spotlight-like
-   *  transitions between steps.
+   * @property {boolean} [animateTooltips=true] - Enables tooltip bouncing at the
+   *  beginning and end of each step.
+   * @property {boolean} [animateScrolling=true] -
+   *  <p>If the next tooltip is not completely within the client bounds, this
+   *  property animates the scrolling of the viewport until the next tooltip
+   *  is centered.</p>
+   *  <p>If false, the viewport is not scrolled.</p
+   * @property {integer} [scrollAnimationDuration=500] - Specifies the duration
+   *  of the scroll animation above, in milliseconds.
+   *  Ignored if animateScrolling is false.
    */
 
   /**
@@ -65,12 +75,18 @@ class Tutorial {
     if (configType === '[object Array]') {
       stepConfigs = config;
       overlayConfig = {};
+      this.animateTooltips = true;
+      this.animateScrolling = true;
+      this.scrollAnimationDuration = DEFAULT_SCROLL_ANIMATION_DURATION;
     } else if (configType === '[object Object]') {
       if (!Array.isArray(config.steps)) {
         throw new Error(`steps must be an array.\n${this}`);
       }
       this.zIndex = config.zIndex;
       this.useTransparentOverlayStrategy = config.useTransparentOverlayStrategy;
+      this.animateTooltips = config.animateTooltips === undefined ? true : config.animateTooltips;
+      this.animateScrolling = config.animateScrolling === undefined ? true : config.animateScrolling;
+      this.scrollAnimationDuration = config.scrollAnimationDuration || DEFAULT_SCROLL_ANIMATION_DURATION;
       stepConfigs = config.steps;
       overlayConfig = config;
     } else {
@@ -78,8 +94,8 @@ class Tutorial {
     }
 
     this.overlay = new Overlay(overlayConfig);
-    stepConfigs.forEach((step, index) => {
-      this.steps.push(new Step(step, index, this, this.overlay, this.delegate));
+    stepConfigs.forEach((stepConfig, index) => {
+      this.steps.push(new Step(stepConfig, index, this, this.overlay, this.delegate));
     });
     this._prepared = false;
     this._isActive = false;

--- a/stylesheets/tooltip.scss
+++ b/stylesheets/tooltip.scss
@@ -21,3 +21,40 @@
     transform-origin: 50% 50% 0;
   }
 }
+
+$directions: top, right, bottom, left;
+
+@each $direction in $directions {
+  .animate-appear-#{$direction} {
+    animation: appear-#{$direction} 0.4s ease-in;
+    animation-fill-mode: forwards;
+  }
+}
+
+@each $direction in $directions {
+  $margin-direction: null;
+  @if ($direction == left) or ($direction == right) {
+    $margin-direction: left;
+  } @else {
+    $margin-direction: top;
+  }
+
+  $reverse: 1;
+  @if ($direction == left) or ($direction == top) {
+    $reverse: -1;
+  }
+
+  @keyframes appear-#{$direction} {
+    0% {
+      margin-#{$margin-direction}: #{10 * $reverse}px;
+      opacity: 0;
+    }
+    50% {
+      margin-#{$margin-direction}: #{-5 * $reverse}px;
+    }
+    100% {
+      margin-#{$margin-direction}: 0px;
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
- Addresses #22: Adds CSS animations to bounce the tooltips at beginning and end of each step.
- Added a scrolling animation that will scroll the tooltip into view if it's not currently within the client bounds

Dependencies on following PRs: https://github.com/zendesk/chariot/pull/54, https://github.com/zendesk/chariot/pull/55, https://github.com/zendesk/chariot/pull/60

@zenrfung 

__Testing__
- Tested IE10 compatibility