### PR TITLE
Tutorial parameter is now stripped after tutorial ends

### DIFF
--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -240,6 +240,12 @@ class Tutorial {
       }
     }).then(() => {
       this._isActive = false;
+      // Remove tutorial query parameter from URL
+      const match = window.location.href.match(/\?.*tutorial=([^&]*)/);
+      if (match && match.length) {
+        const newUrl = window.location.href.replace(/tutorial=([^&]*)/, '');
+        history.pushState({ path: newUrl }, '', newUrl)
+      }
     });
   }
 


### PR DESCRIPTION
Tutorial parameter is now stripped from the window href after the tutorial ends. This prevents conflicts when another tutorial is started programmatically while the query param persists.

@zenrfung @th11 