### PR TITLE
[EGMT-1830] Add new config setting to enable clone interaction

### DIFF
--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -11,6 +11,7 @@ class Overlay {
     this.overlayColor = config.overlayColor || 'rgba(255,255,255,0.8)';
     this.useTransparentOverlayStrategy = !!config.useTransparentOverlayStrategy;
     this._resizeHandler = null;
+    this.disableCloneInteraction = config.disableCloneInteraction === undefined ? true : config.disableCloneInteraction;
   }
 
   isVisible() {
@@ -26,9 +27,11 @@ class Overlay {
     $body.append($overlay);
     this.$overlay = $overlay;
 
-    let $transparentOverlay = this._createTransparentOverlay();
-    $body.append($transparentOverlay);
-    this.$transparentOverlay = $transparentOverlay;
+    if (this.disableCloneInteraction) {
+      const $transparentOverlay = this._createTransparentOverlay();
+      $body.append($transparentOverlay);
+      this.$transparentOverlay = $transparentOverlay;
+    }
   }
 
   isTransparentOverlayStrategy() {

--- a/lib/step.js
+++ b/lib/step.js
@@ -204,7 +204,9 @@ class Step {
   _clonedElementStrategy() {
     // Clone elements if multiple selectors
     this._cloneElements(this.selectors);
-    this.overlay.showTransparentOverlay();
+    if (this.overlay.disableCloneInteraction) {
+      this.overlay.showTransparentOverlay();
+    }
   }
 
   _renderTooltip() {
@@ -281,6 +283,9 @@ class Step {
     }
     $clone.addClass('chariot-clone');
     Style.cloneStyles($element, $clone);
+    if (this.overlay.disableCloneInteraction) {
+      $clone.css('pointer-events', 'none');
+    }
     let clonedChildren = $clone.children().toArray();
     $element.children().toArray().forEach((child, index) => {
       this._applyComputedStyles($(clonedChildren[index]), $(child));

--- a/lib/style.js
+++ b/lib/style.js
@@ -59,7 +59,6 @@ class Style {
       this._ieBoxModelStyleFix('width', $clone, cssText);
       this._ieBoxModelStyleFix('height', $clone, cssText);
     }
-    $clone.css('pointer-events', 'none');
     //this._clonePseudoStyle($element, $clone, 'before');
     //this._clonePseudoStyle($element, $clone, 'after');
   }

--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -42,6 +42,8 @@ class Tutorial {
    * @property {boolean} [shouldOverlay=true] - Setting to false will disable the
    * overlay that normally appears over the page and behind the tooltips.
    * @property {string} [overlayColor='rgba(255,255,255,0.7)'] - Overlay CSS color
+   * @property {boolean} [disableCloneInteraction=true] - Setting to false will allow the
+   * user to interact with the cloned element (eg. click on links)
    * @property {Tutorial-onCompleteCallback} [onComplete] - Callback that is called
    * once the tutorial has gone through all steps.
    * @property {boolean} [useTransparentOverlayStrategy=false] - <p>


### PR DESCRIPTION
@zendesk/growth 

In order to interact with cloned elements, remove the transparent overlay and do not set pointer-events to none

## Risks
Low
When `disableCloneInteraction` is set to false in a Chariot config, allow the user to click on the clone as if it were the real element